### PR TITLE
商品一覧表示機能実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,10 +3,6 @@ class ItemsController < ApplicationController
 
   def index
     @items = Item.all.order(id: 'DESC')
-    @feebearings = []
-    2.times do |i|
-      @feebearings[i + 2] = Feebearing.find(i + 2)
-    end
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,12 +2,11 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: :index
 
   def index
-    @items = Item.all.order(id: "DESC")
+    @items = Item.all.order(id: 'DESC')
     @feebearings = []
     2.times do |i|
-      @feebearings[i + 2] = Feebearing.find (i + 2)
+      @feebearings[i + 2] = Feebearing.find(i + 2)
     end
-    binding.pry
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,12 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: :index
 
   def index
+    @items = Item.all.order(id: "DESC")
+    @feebearings = []
+    2.times do |i|
+      @feebearings[i + 2] = Feebearing.find (i + 2)
+    end
+    binding.pry
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,35 +126,35 @@
     <%= link_to '新規投稿商品', new_item_path, class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <% if @item != [] %>
+      <% if @items != [] %>
         <li class='list'>
-          <%= link_to "#" do %>
-          <div class='item-img-content'>
-            <%= image_tag "item-sample.png", class: "item-img" %>
+          <% @items.each do |item| %>
+            <%= link_to "#" do %>
+              <div class='item-img-content'>
+                <%= image_tag item.image, class: "item-img" %>
 
-            <%# 商品が売れていればsold outを表示しましょう %>
-            <div class='sold-out'>
-              <span>Sold Out!!</span>
-            </div>
-            <%# //商品が売れていればsold outを表示しましょう %>
+                <%# 商品が売れていればsold outを表示しましょう %>
+                <div class='sold-out'>
+                  <span>Sold Out!!</span>
+                </div>
+                <%# //商品が売れていればsold outを表示しましょう %>
 
-          </div>
-          <div class='item-info'>
-            <h3 class='item-name'>
-              <%= "商品名" %>
-            </h3>
-            <div class='item-price'>
-              <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-              <div class='star-btn'>
-                <%= image_tag "star.png", class:"star-icon" %>
-                <span class='star-count'>0</span>
               </div>
-            </div>
-          </div>
+              <div class='item-info'>
+                <h3 class='item-name'>
+                  <%= item.name %>
+                </h3>
+                <div class='item-price'>
+                  <span><%= item.price %>円<br><%= @feebearings[item.feebearing_id].name %></span>
+                  <div class='star-btn'>
+                    <%= image_tag "star.png", class:"star-icon" %>
+                    <span class='star-count'>0</span>
+                  </div>
+                </div>
+              </div>
+            <% end %>
           <% end %>
         </li>
-        <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <% else %>
         <li class='list'>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,8 +127,8 @@
     <ul class='item-lists'>
 
       <% if @items != [] %>
-        <li class='list'>
-          <% @items.each do |item| %>
+        <% @items.each do |item| %>
+          <li class='list'>
             <%= link_to "#" do %>
               <div class='item-img-content'>
                 <%= image_tag item.image, class: "item-img" %>
@@ -145,7 +145,7 @@
                   <%= item.name %>
                 </h3>
                 <div class='item-price'>
-                  <span><%= item.price %>円<br><%= @feebearings[item.feebearing_id].name %></span>
+                  <span><%= item.price %>円<br><%= item.feebearing.name %></span>
                   <div class='star-btn'>
                     <%= image_tag "star.png", class:"star-icon" %>
                     <span class='star-count'>0</span>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -123,59 +123,58 @@
   <%# 商品一覧 %>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
-    <%= link_to '新規投稿商品', "#", class: "subtitle" %>
+    <%= link_to '新規投稿商品', new_item_path, class: "subtitle" %>
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+      <% if @item != [] %>
+        <li class='list'>
+          <%= link_to "#" do %>
+          <div class='item-img-content'>
+            <%= image_tag "item-sample.png", class: "item-img" %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
+            <%# 商品が売れていればsold outを表示しましょう %>
+            <div class='sold-out'>
+              <span>Sold Out!!</span>
+            </div>
+            <%# //商品が売れていればsold outを表示しましょう %>
+
           </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              <%= "商品名" %>
+            </h3>
+            <div class='item-price'>
+              <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
             </div>
           </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+          <% end %>
+        </li>
+        <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+      <% else %>
+        <li class='list'>
+          <%= link_to new_item_path do %>
+          <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              商品を出品してね！
+            </h3>
+            <div class='item-price'>
+              <span>99999999円<br>(税込み)</span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
             </div>
           </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+          <% end %>
+        </li>
+      <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -102,7 +102,6 @@ RSpec.describe Item, type: :model do
         @item.valid?
         expect(@item.errors.full_messages).to include('Price ：販売価格は¥300〜9,999,999の範囲で、半角数字で入力してください')
       end
-
     end
   end
 end


### PR DESCRIPTION
# What
出品された商品がトップページに一覧表示されるように実装
- 商品画像、商品名、値段、支払い方法を表示
- 新しい投稿が上に来るように表示
- ログアウト状態でも一覧表示可能

# Why
トップページに出品された商品の一覧を表示させるため

# 動作確認GIF
- 商品登録→トップページ表示確認
https://gyazo.com/96dcadcbac5f21ea8b212bf055a9cab6
- トップページ表示確認（過去に出品したもの）
https://gyazo.com/45b8b0b33f78120c47e8717670f652bb
- ログアウト状態でも商品一覧が表示されることを確認
https://gyazo.com/65e05d237800eec3d682ed7857c8a59b